### PR TITLE
Fix the build to correctly assert error messages from the command line

### DIFF
--- a/test/integration/logstash-cli/serverspec/plugin_install_spec.rb
+++ b/test/integration/logstash-cli/serverspec/plugin_install_spec.rb
@@ -28,10 +28,10 @@ context "bin/plugin install" do
   context "when the plugin doesn't exist" do
     describe command("/opt/logstash/bin/plugin install logstash-output-impossible-plugin") do
       its(:exit_status) { is_expected.to eq(1) }
-      its(:stdout) { is_expected.to match(/Plugin logstash-output-impossible-plugin does not exist/) }
+      its(:stderr) { is_expected.to match(/Plugin logstash-output-impossible-plugin does not exist/) }
 
       describe command("/opt/logstash/bin/plugin list logstash-output-impossible-plugin") do
-        its(:stdout) { is_expected.to match(/No plugins found/) }
+        its(:stderr) { is_expected.to match(/No plugins found/) }
       end
     end
   end

--- a/test/integration/logstash-cli/serverspec/plugin_uninstall_spec.rb
+++ b/test/integration/logstash-cli/serverspec/plugin_uninstall_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../kitchen/files/spec_helper"
 describe "bin/plugin uninstall" do
   context "when the plugin isn't installed" do
     describe command("/opt/logstash/bin/plugin uninstall logstash-filter-cidr") do
-      its(:stdout) { is_expected.to match(/ERROR: Uninstall Aborted, message: This plugin has not been previously installed, aborting/)  }
+      its(:stderr) { is_expected.to match(/ERROR: Uninstall Aborted, message: This plugin has not been previously installed, aborting/)  }
       its(:exit_status) { is_expected.to eq(1) }
     end
   end


### PR DESCRIPTION
We have change how we are reporting the errors in logstash, before all
the errors were send to the `stdout` which is the wrong way to do it.
Now all the errors are actually send to the right output which is `stderr`.

Fixes #7